### PR TITLE
feat: install theme from `src/` directory

### DIFF
--- a/.github/workflows/build-docker-image.yaml
+++ b/.github/workflows/build-docker-image.yaml
@@ -37,7 +37,7 @@ jobs:
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
         with:
-          context: ./ckan
+          file: ckan/Dockerfile
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/ckan/Dockerfile
+++ b/ckan/Dockerfile
@@ -21,18 +21,18 @@ RUN find /srv/app -gid 502 ! -type l -exec chgrp 826671 {} \;
 USER ckan
 
 RUN pip install ckanext-geoview
-ADD requirements/ckanext-spatial.txt /tmp/
+ADD ckan/requirements/ckanext-spatial.txt /tmp/
 RUN pip3 install -r /tmp/ckanext-spatial.txt
 RUN pip3 install -e "git+https://github.com/ckan/ckanext-spatial.git#egg=ckanext-spatial"
 RUN pip3 install -e 'git+https://github.com/mosoriob/ckanext-oauth2.git@0.8.1#egg=ckanext-oauth2'
 RUN pip3 install -e 'git+https://github.com/mosoriob/ckanext-tacc_theme.git@74ca927ddc5eba8c6d176e44e5d9fb08ec3e351c#egg=ckanext-tacc_theme'
 
 # Copy custom initialization scripts
-COPY docker-entrypoint.d/* /docker-entrypoint.d/
+COPY ckan/docker-entrypoint.d/* /docker-entrypoint.d/
 
 # Apply any patches needed to CKAN core or any of the built extensions (not the
 # runtime mounted ones)
-COPY patches ${APP_DIR}/patches
+COPY ckan/patches ${APP_DIR}/patches
 
 RUN for d in $APP_DIR/patches/*; do \
     if [ -d $d ]; then \

--- a/ckan/Dockerfile
+++ b/ckan/Dockerfile
@@ -25,10 +25,12 @@ ADD ckan/requirements/ckanext-spatial.txt /tmp/
 RUN pip3 install -r /tmp/ckanext-spatial.txt
 RUN pip3 install -e "git+https://github.com/ckan/ckanext-spatial.git#egg=ckanext-spatial"
 RUN pip3 install -e 'git+https://github.com/mosoriob/ckanext-oauth2.git@0.8.1#egg=ckanext-oauth2'
-RUN pip3 install -e 'git+https://github.com/mosoriob/ckanext-tacc_theme.git@74ca927ddc5eba8c6d176e44e5d9fb08ec3e351c#egg=ckanext-tacc_theme'
-
+#RUN pip3 install -e 'git+https://github.com/mosoriob/ckanext-tacc_theme.git@74ca927ddc5eba8c6d176e44e5d9fb08ec3e351c#egg=ckanext-tacc_theme'
+#COPY src/ckanext-tacc_theme ${APP_DIR}/src/ckanext-tacc_theme
+#RUN chown -R ckan:ckan-sys /srv/app/.local
+#RUN cd ${APP_DIR}/src/ckanext-tacc_theme && python3 setup.py develop --user
 # Copy custom initialization scripts
-COPY ckan/docker-entrypoint.d/* /docker-entrypoint.d/
+#COPY ckan/docker-entrypoint.d/* /docker-entrypoint.d/
 
 # Apply any patches needed to CKAN core or any of the built extensions (not the
 # runtime mounted ones)

--- a/ckan/Dockerfile
+++ b/ckan/Dockerfile
@@ -25,10 +25,9 @@ ADD ckan/requirements/ckanext-spatial.txt /tmp/
 RUN pip3 install -r /tmp/ckanext-spatial.txt
 RUN pip3 install -e "git+https://github.com/ckan/ckanext-spatial.git#egg=ckanext-spatial"
 RUN pip3 install -e 'git+https://github.com/mosoriob/ckanext-oauth2.git@0.8.1#egg=ckanext-oauth2'
-#RUN pip3 install -e 'git+https://github.com/mosoriob/ckanext-tacc_theme.git@74ca927ddc5eba8c6d176e44e5d9fb08ec3e351c#egg=ckanext-tacc_theme'
-#COPY src/ckanext-tacc_theme ${APP_DIR}/src/ckanext-tacc_theme
-#RUN chown -R ckan:ckan-sys /srv/app/.local
-#RUN cd ${APP_DIR}/src/ckanext-tacc_theme && python3 setup.py develop --user
+
+COPY --chown=ckan:ckan-sys src/ckanext-tacc_theme ${APP_DIR}/src/ckanext-tacc_theme
+RUN cd ${APP_DIR}/src/ckanext-tacc_theme && python3 setup.py develop --user
 # Copy custom initialization scripts
 #COPY ckan/docker-entrypoint.d/* /docker-entrypoint.d/
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,8 +12,7 @@ volumes:
 services:
   ckan:
     build:
-      context: ckan/
-      dockerfile: Dockerfile
+      dockerfile: ckan/Dockerfile
       args:
         - TZ=${TZ}
     networks:


### PR DESCRIPTION
In this pull request, I propose keeping the theme code in the current repository for now, as it was previously located here:
https://github.com/In-For-Disaster-Analytics/ckanext-tacc_theme.

Given the current situation, maintaining the code in the same place seems more practical at this time.

Changes:

Kept the theme code in the current repository rather than moving it.
Rationale:

This approach avoids unnecessary changes and simplifies the workflow for the moment.
Next Steps:

Review the proposed changes and confirm if this approach works, or if any modifications are needed.
