### PR TITLE
fix: standardize MINT Dataset Schema Field Names and Simplify Variable Input

### DIFF
--- a/src/ckanext-dso_scheming/ckanext/dso_scheming/mint_dataset.yaml
+++ b/src/ckanext-dso_scheming/ckanext/dso_scheming/mint_dataset.yaml
@@ -68,15 +68,15 @@ dataset_fields:
     display_snippet: email.html
     display_email_name_field: maintainer
 
-  - field_name: Temporal Coverage Start
+  - field_name: temporal_coverage_start
     label: Temporal Coverage Start
     preset: date
 
-  - field_name: Temporal Coverage End
+  - field_name: temporal_coverage_end
     label: Temporal Coverage End
     preset: date
 
-  - field_name: MINT Standard Variables
+  - field_name: mint_standard_variables
     label: MINT Standard Variables
     help_allow_html: true
     help_text: Add a MINT Standard Variable <a href="https://api.models.mint.tacc.utexas.edu/v1.8.0/standardvariables?username=mint@isi.edu" target="_blank">List of Standard Variables</a>
@@ -100,15 +100,15 @@ resource_fields:
     label: Format
     preset: resource_format_autocomplete
 
-  - field_name: Temporal Coverage Start
+  - field_name: temporal_coverage_start
     label: Temporal Coverage Start
     preset: date
 
-  - field_name: Temporal Coverage End
+  - field_name: temporal_coverage_end
     label: Temporal Coverage End
     preset: date
 
-  - field_name: MINT Standard Variables
+  - field_name: mint_standard_variables
     label: MINT Standard Variables
     help_allow_html: true
     help_text: Add a MINT Standard Variable <a href="https://api.models.mint.tacc.utexas.edu/v1.8.0/standardvariables?username=mint@isi.edu" target="_blank">List of Standard Variables</a>

--- a/src/ckanext-dso_scheming/ckanext/dso_scheming/mint_dataset.yaml
+++ b/src/ckanext-dso_scheming/ckanext/dso_scheming/mint_dataset.yaml
@@ -79,7 +79,7 @@ dataset_fields:
   - field_name: mint_standard_variables
     label: MINT Standard Variables
     help_allow_html: true
-    help_text: Add a MINT Standard Variable <a href="https://api.models.mint.tacc.utexas.edu/v1.8.0/standardvariables?username=mint@isi.edu" target="_blank">List of Standard Variables</a>
+    help_text: List of MINT Standard Variables https://api.models.mint.tacc.utexas.edu/v1.8.0/standardvariables?username=mint@isi.edu
     preset: multiple_text
 
 resource_fields:
@@ -111,5 +111,5 @@ resource_fields:
   - field_name: mint_standard_variables
     label: MINT Standard Variables
     help_allow_html: true
-    help_text: Add a MINT Standard Variable <a href="https://api.models.mint.tacc.utexas.edu/v1.8.0/standardvariables?username=mint@isi.edu" target="_blank">List of Standard Variables</a>
+    help_text: List of MINT Standard Variables https://api.models.mint.tacc.utexas.edu/v1.8.0/standardvariables?username=mint@isi.edu
     preset: multiple_text

--- a/src/ckanext-dso_scheming/ckanext/dso_scheming/mint_dataset.yaml
+++ b/src/ckanext-dso_scheming/ckanext/dso_scheming/mint_dataset.yaml
@@ -80,10 +80,7 @@ dataset_fields:
     label: MINT Standard Variables
     help_allow_html: true
     help_text: Add a MINT Standard Variable <a href="https://api.models.mint.tacc.utexas.edu/v1.8.0/standardvariables?username=mint@isi.edu" target="_blank">List of Standard Variables</a>
-    repeating_subfields:
-      - field_name: Standard Variable Label
-        label: Standard Variable Label
-        form_placeholder: air__daily_max_of_temperature
+    preset: multiple_text
 
 resource_fields:
   - field_name: url
@@ -115,7 +112,4 @@ resource_fields:
     label: MINT Standard Variables
     help_allow_html: true
     help_text: Add a MINT Standard Variable <a href="https://api.models.mint.tacc.utexas.edu/v1.8.0/standardvariables?username=mint@isi.edu" target="_blank">List of Standard Variables</a>
-    repeating_subfields:
-      - field_name: Standard Variable Label
-        label: Standard Variable Label
-        form_placeholder: air__daily_max_of_temperature
+    preset: multiple_text


### PR DESCRIPTION
## Changes
This PR includes improvements to the MINT dataset schema configuration:

1. **Field Name Standardization**
   - Converted field names to follow consistent lowercase with underscore convention
   - Updated:
     - `Temporal Coverage Start` → `temporal_coverage_start`
     - `Temporal Coverage End` → `temporal_coverage_end`
     - `MINT Standard Variables` → `mint_standard_variables`

2. **MINT Standard Variables Input Simplification**
   - Replaced complex `repeating_subfields` structure with `multiple_text` preset
   - Simplified help text formatting while maintaining the same reference URL
   - Applied changes consistently in both dataset and resource field sections

## Why
- Improves consistency in field naming across the schema
- Simplifies the data input process for MINT Standard Variables
- Makes the schema more maintainable and easier to work with
- Aligns with CKAN naming conventions

## Testing
Please verify:
- Dataset creation and editing works with the new field names
- MINT Standard Variables can be properly added using the multiple_text input
- Temporal coverage dates can be set correctly
- Existing datasets remain accessible and editable
