### PR TITLE
add CKAN Pages Extension and Infrastructure Improvements

### DIFF
--- a/.env.dev.config
+++ b/.env.dev.config
@@ -32,7 +32,7 @@ CKAN_DATAPUSHER_URL=http://datapusher:8800
 CKAN__DATAPUSHER__CALLBACK_URL_BASE=http://ckan-dev:5000
 
 # Extensions
-CKAN__PLUGINS="datatables_view text_view image_view audio_view video_view webpage_view pdf_view datastore datapusher envvars spatial_metadata spatial_query geo_view scheming_datasets scheming_groups scheming_organizations dso_scheming tacc_theme showcase"
+CKAN__PLUGINS="datatables_view text_view image_view audio_view video_view webpage_view pdf_view datastore datapusher envvars spatial_metadata spatial_query geo_view scheming_datasets scheming_groups scheming_organizations dso_scheming tacc_theme showcase pages"
 # ckan.views.default_views
 CKAN__VIEWS__DEFAULT_VIEWS = "image_view text_view datatables_view pdf_view geojson_view"
 

--- a/.env.prod.config
+++ b/.env.prod.config
@@ -29,7 +29,7 @@ CKAN_DATAPUSHER_URL=http://datapusher:8800
 CKAN__DATAPUSHER__CALLBACK_URL_BASE=http://ckan:5000
 
 # Extensions
-CKAN__PLUGINS="datatables_view text_view image_view audio_view video_view webpage_view pdf_view datapusher envvars spatial_metadata spatial_query geo_view scheming_datasets scheming_groups scheming_organizations dso_scheming tacc_theme showcase oauth2"
+CKAN__PLUGINS="datatables_view text_view image_view audio_view video_view webpage_view pdf_view datapusher envvars spatial_metadata spatial_query geo_view scheming_datasets scheming_groups scheming_organizations dso_scheming tacc_theme showcase oauth2 pages"
 CKAN__VIEWS__DEFAULT_VIEWS = "image_view text_view datatables_view pdf_view geojson_view"
 
 # Harvest

--- a/ckan/Dockerfile.dev
+++ b/ckan/Dockerfile.dev
@@ -20,11 +20,6 @@ RUN pip3 install "git+https://github.com/ckan/ckanext-showcase.git#egg=ckanext-s
 RUN pip3 install "git+https://github.com/ckan/ckanext-scheming.git#egg=ckanext-scheming"
 RUN pip3 install -e "git+https://github.com/ckan/ckanext-pages.git#egg=ckanext-pages"
 COPY docker-entrypoint.d/* /docker-entrypoint.d/
-
-COPY --chown=ckan:ckan-sys src/ckanext-dso_scheming ${APP_DIR}/src/ckanext-dso_scheming
-RUN cd ${APP_DIR}/src/ckanext-dso_scheming && python3 setup.py develop --user
-# Apply any patches needed to CKAN core or any of the built extensions (not the
-# runtime mounted ones)
 COPY patches ${APP_DIR}/patches
 
 RUN for d in $APP_DIR/patches/*; do \

--- a/ckan/Dockerfile.dev
+++ b/ckan/Dockerfile.dev
@@ -13,6 +13,7 @@ USER ckan
 RUN pip3 install ckanext-geoview
 ADD requirements/ckanext-spatial.txt /tmp/
 RUN pip3 install ckanext-pdfview
+
 RUN pip3 install -r /tmp/ckanext-spatial.txt
 RUN pip3 install "git+https://github.com/ckan/ckanext-spatial.git#egg=ckanext-spatial"
 RUN pip3 install "git+https://github.com/ckan/ckanext-showcase.git#egg=ckanext-showcase"
@@ -20,6 +21,8 @@ RUN pip3 install "git+https://github.com/ckan/ckanext-scheming.git#egg=ckanext-s
 RUN pip3 install -e "git+https://github.com/ckan/ckanext-pages.git#egg=ckanext-pages"
 COPY docker-entrypoint.d/* /docker-entrypoint.d/
 
+COPY --chown=ckan:ckan-sys src/ckanext-dso_scheming ${APP_DIR}/src/ckanext-dso_scheming
+RUN cd ${APP_DIR}/src/ckanext-dso_scheming && python3 setup.py develop --user
 # Apply any patches needed to CKAN core or any of the built extensions (not the
 # runtime mounted ones)
 COPY patches ${APP_DIR}/patches

--- a/ckan/Dockerfile.dev
+++ b/ckan/Dockerfile.dev
@@ -7,6 +7,7 @@ RUN apt-get install -y python3-dev libxml2-dev libxslt1-dev libgeos-c1v5 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
+USER ckan
 RUN pip3 install ckanext-geoview
 ADD requirements/ckanext-spatial.txt /tmp/
 RUN pip3 install ckanext-pdfview

--- a/ckan/Dockerfile.dev
+++ b/ckan/Dockerfile.dev
@@ -17,6 +17,7 @@ RUN pip3 install -r /tmp/ckanext-spatial.txt
 RUN pip3 install "git+https://github.com/ckan/ckanext-spatial.git#egg=ckanext-spatial"
 RUN pip3 install "git+https://github.com/ckan/ckanext-showcase.git#egg=ckanext-showcase"
 RUN pip3 install "git+https://github.com/ckan/ckanext-scheming.git#egg=ckanext-scheming"
+RUN pip3 install -e "git+https://github.com/ckan/ckanext-pages.git#egg=ckanext-pages"
 COPY docker-entrypoint.d/* /docker-entrypoint.d/
 
 # Apply any patches needed to CKAN core or any of the built extensions (not the

--- a/ckan/Dockerfile.dev
+++ b/ckan/Dockerfile.dev
@@ -7,6 +7,8 @@ RUN apt-get install -y python3-dev libxml2-dev libxslt1-dev libgeos-c1v5 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
+RUN chown -R ckan: /srv/app
+
 USER ckan
 RUN pip3 install ckanext-geoview
 ADD requirements/ckanext-spatial.txt /tmp/

--- a/ckan/docker-entrypoint.d/02_setup_pages.sh
+++ b/ckan/docker-entrypoint.d/02_setup_pages.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+ckan -c /srv/app/ckan.ini db upgrade -p pages

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -19,7 +19,7 @@ services:
     volumes:
       # The volume to chown
       - ./src:/srv/app/src_extensions
-    command: chown -R :502 /srv/app/src_extensions && chmod -R 775 /srv/app/src_extensions
+    command: sh -c 'chown -R :502 /srv/app/src_extensions && chmod -R 775 /srv/app/src_extensions'
 
   ckan-dev:
     build:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -8,6 +8,19 @@ volumes:
   home_dir_dev:
 
 services:
+  change-vol-ownership:
+    # We can use any image we want as long as we can chown
+    image: busybox
+    # Need a user priviliged enough to chown
+    user: 'root'
+    # Specify the group in question
+    group_add:
+      - '502'
+    volumes:
+      # The volume to chown
+      - ./src:/srv/app/src_extensions
+    command: chown -R :502 /srv/app/src_extensions && chmod -R 775 /srv/app/src_extensions
+
   ckan-dev:
     build:
       context: ckan/
@@ -36,6 +49,8 @@ services:
       interval: 60s
       timeout: 10s
       retries: 3
+    depends_on:
+      - change-vol-ownership
 
   datapusher:
     image: ckan/ckan-base-datapusher:0.0.20

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,11 +1,11 @@
 volumes:
-  ckan_storage:
-  pg_data:
-  solr_data:
-  pip_cache:
-  site_packages:
-  local_bin:
-  home_dir:
+  ckan_storage_dev:
+  pg_data_dev:
+  solr_data_dev:
+  pip_cache_dev:
+  site_packages_dev:
+  local_bin_dev:
+  home_dir_dev:
 
 services:
   ckan-dev:
@@ -24,12 +24,12 @@ services:
     ports:
       - '0.0.0.0:5000:5000'
     volumes:
-      - ckan_storage:/var/lib/ckan
+      - ckan_storage_dev:/var/lib/ckan
       - ./src:/srv/app/src_extensions
-      - pip_cache:/root/.cache/pip
-      - site_packages:/usr/local/lib/python3.10/site-packages
-      - local_bin:/usr/local/bin
-      - home_dir:/srv/app/
+      - pip_cache_dev:/root/.cache/pip
+      - site_packages_dev:/usr/local/lib/python3.10/site-packages
+      - local_bin_dev:/usr/local/bin
+      - home_dir_dev:/srv/app/
     restart: unless-stopped
     healthcheck:
       test: ['CMD', 'wget', '-qO', '/dev/null', 'http://localhost:5000']
@@ -56,7 +56,7 @@ services:
       - .env.dev.config
       - .env.dev.secrets
     volumes:
-      - pg_data:/var/lib/postgresql/data
+      - pg_data_dev:/var/lib/postgresql/data
     restart: unless-stopped
     healthcheck:
       test: ['CMD', 'pg_isready', '-U', 'postgres', '-d', 'postgres']
@@ -64,7 +64,7 @@ services:
   solr:
     image: ckan/ckan-solr:2.9-solr9-spatial
     volumes:
-      - solr_data:/var/solr
+      - solr_data_dev:/var/solr
     restart: unless-stopped
     healthcheck:
       test: ['CMD', 'wget', '-qO', '/dev/null', 'http://localhost:8983/solr/']


### PR DESCRIPTION
# Add CKAN Pages Extension and Infrastructure Improvements

## Changes
- Added CKAN Pages extension to both development and production environments
- Added necessary database migration script for Pages extension
- Updated Dockerfile.dev to install ckanext-pages from GitHub
- Improved volume naming in docker-compose.dev.yml to prevent conflicts
- Added volume ownership fix for development environment
- Added proper user permissions in Dockerfile.dev

## Technical Details
- Added `pages` to CKAN__PLUGINS in both .env.dev.config and .env.prod.config
- Created new docker-entrypoint.d script (02_setup_pages.sh) for Pages extension database setup
- Modified volume names in docker-compose.dev.yml to include `_dev` suffix
- Added new `change-vol-ownership` service to handle volume permissions
- Updated Dockerfile.dev to run as `ckan` user and set proper ownership

## Testing
- [ ] Verify Pages extension is properly installed and configured
- [ ] Test database migrations run successfully
- [ ] Confirm volume permissions are correct in development environment
- [ ] Verify Pages functionality works as expected

## Notes
- The Pages extension will allow for creating and managing custom pages in CKAN
- Volume naming changes help prevent conflicts between development and production environments
- User permission changes improve security by not running as root


- **fix: run as useer**
- **fix: permissions**
- **add: pages**
- **fix: suffix dev to all volume**
- **refactor: remove deprecated ckanext-dso_scheming installation from Dockerfile.dev**
- **add: new service for changing volume ownership in Docker Compose**
- **fix: update command syntax for volume ownership in Docker Compose**
- **update: add 'pages' plugin to CKAN configuration in development and production environments**
