### PR TITLE
fix(oauth2): bump ckanext-oauth2 to v1.2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 docs/superpowers
+.worktrees
 migration_backups/
 .planning
 .venv/

--- a/ckan/Dockerfile
+++ b/ckan/Dockerfile
@@ -25,7 +25,7 @@ RUN pip install ckanext-geoview
 ADD ckan/requirements/ckanext-spatial.txt /tmp/
 RUN pip3 install -r /tmp/ckanext-spatial.txt
 RUN pip3 install -e "git+https://github.com/ckan/ckanext-spatial.git#egg=ckanext-spatial"
-RUN pip3 install -e 'git+https://github.com/In-For-Disaster-Analytics/ckanext-oauth2.git@v1.1.0#egg=ckanext-oauth2'
+RUN pip3 install -e 'git+https://github.com/In-For-Disaster-Analytics/ckanext-oauth2.git@v1.2.0#egg=ckanext-oauth2'
 RUN pip3 install -e "git+https://github.com/ckan/ckanext-showcase.git#egg=ckanext-showcase"
 RUN pip3 install -e "git+https://github.com/ckan/ckanext-pages.git#egg=ckanext-pages"
 RUN pip3 install -e "git+https://github.com/ckan/ckanext-scheming.git#egg=ckanext-scheming"


### PR DESCRIPTION
## Summary

- Bump ckanext-oauth2 from v1.1.0 to v1.2.0 in Dockerfile
- Update submodule pointer to include bearer-token auth fixes

## What's in v1.2.0

- Register Flask-Login `request_loader` so `current_user` is correctly resolved for API requests using `Authorization: Bearer` or `X-Tapis-Token` headers
- Add early-return guard in `identify()` to skip redundant JWT decode for session-authenticated requests
- Fix `RecursionError` caused by storing the `current_user` LocalProxy instead of the concrete User model in `g.userobj`

## Test plan

- [x] Unit tests pass (`CKAN_INI=test.ini uv run pytest`)
- [x] `Authorization: Bearer` API calls resolve authenticated user
- [x] `X-Tapis-Token` API calls resolve authenticated user
- [x] Browser session login works without RecursionError
- [x] Verified on production (ckan.tacc.utexas.edu)