### PR TITLE
Fix Corral EDQUOT: migrate CKAN storage to PT2050-DataX (gid 820466)

### DIFF
--- a/ckan/Dockerfile
+++ b/ckan/Dockerfile
@@ -4,7 +4,7 @@ FROM ckan/ckan-base:2.11
 
 USER root
 RUN apt-get update && \
-    apt-get install -y python3-dev libxml2-dev libxslt1-dev libgeos-c1v5 \
+    apt-get install -y python3-dev libxml2-dev libxslt1-dev libgeos-c1v5 procps \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/ckan/Dockerfile
+++ b/ckan/Dockerfile
@@ -10,15 +10,15 @@ RUN apt-get update && \
 
 RUN chown -R ckan: /srv/app
 
-RUN groupmod -g 826671 ckan-sys && echo "Modified group ID for ckan-sys to 826671"
+RUN groupmod -g 820466 ckan-sys && echo "Modified group ID for ckan-sys to 820466"
 RUN usermod -u 863242 ckan && echo "Modified user ID for ckan to 863242"
 
-RUN find /var/lib/ckan -gid 502 ! -type l -exec chgrp 826671 {} \;
-RUN find ${APP_DIR} -gid 502 ! -type l -exec chgrp 826671 {} \;
-RUN find /docker-entrypoint.d -gid 502 ! -type l -exec chgrp 826671 {} \;
-RUN find /usr/local -gid 502 ! -type l -exec chgrp 826671 {} \;
-RUN find ${CKAN_STORAGE_PATH} -gid 502 ! -type l -exec chgrp 826671 {} \;
-RUN find /srv/app -gid 502 ! -type l -exec chgrp 826671 {} \;
+RUN find /var/lib/ckan -gid 502 ! -type l -exec chgrp 820466 {} \;
+RUN find ${APP_DIR} -gid 502 ! -type l -exec chgrp 820466 {} \;
+RUN find /docker-entrypoint.d -gid 502 ! -type l -exec chgrp 820466 {} \;
+RUN find /usr/local -gid 502 ! -type l -exec chgrp 820466 {} \;
+RUN find ${CKAN_STORAGE_PATH} -gid 502 ! -type l -exec chgrp 820466 {} \;
+RUN find /srv/app -gid 502 ! -type l -exec chgrp 820466 {} \;
 
 RUN find /var/lib/ckan -uid 503 ! -type l -exec chown 863242 {} \;
 RUN find ${APP_DIR} -uid 503 ! -type l -exec chown 863242 {} \;

--- a/ckan/Dockerfile
+++ b/ckan/Dockerfile
@@ -33,7 +33,7 @@ RUN pip install ckanext-geoview
 ADD ckan/requirements/ckanext-spatial.txt /tmp/
 RUN pip3 install -r /tmp/ckanext-spatial.txt
 RUN pip3 install -e "git+https://github.com/ckan/ckanext-spatial.git#egg=ckanext-spatial"
-RUN pip3 install -e 'git+https://github.com/In-For-Disaster-Analytics/ckanext-oauth2.git@v1.2.2 egg=ckanext-oauth2'
+RUN pip3 install -e 'git+https://github.com/In-For-Disaster-Analytics/ckanext-oauth2.git@v1.2.2#egg=ckanext-oauth2'
 RUN pip3 install -e "git+https://github.com/ckan/ckanext-showcase.git#egg=ckanext-showcase"
 RUN pip3 install -e "git+https://github.com/ckan/ckanext-pages.git#egg=ckanext-pages"
 RUN pip3 install -e "git+https://github.com/ckan/ckanext-scheming.git#egg=ckanext-scheming"

--- a/ckan/Dockerfile
+++ b/ckan/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get update && \
 RUN chown -R ckan: /srv/app
 
 RUN groupmod -g 826671 ckan-sys && echo "Modified group ID for ckan-sys to 826671"
+RUN usermod -u 863242 ckan && echo "Modified user ID for ckan to 863242"
 
 RUN find /var/lib/ckan -gid 502 ! -type l -exec chgrp 826671 {} \;
 RUN find ${APP_DIR} -gid 502 ! -type l -exec chgrp 826671 {} \;
@@ -18,6 +19,13 @@ RUN find /docker-entrypoint.d -gid 502 ! -type l -exec chgrp 826671 {} \;
 RUN find /usr/local -gid 502 ! -type l -exec chgrp 826671 {} \;
 RUN find ${CKAN_STORAGE_PATH} -gid 502 ! -type l -exec chgrp 826671 {} \;
 RUN find /srv/app -gid 502 ! -type l -exec chgrp 826671 {} \;
+
+RUN find /var/lib/ckan -uid 503 ! -type l -exec chown 863242 {} \;
+RUN find ${APP_DIR} -uid 503 ! -type l -exec chown 863242 {} \;
+RUN find /docker-entrypoint.d -uid 503 ! -type l -exec chown 863242 {} \;
+RUN find /usr/local -uid 503 ! -type l -exec chown 863242 {} \;
+RUN find ${CKAN_STORAGE_PATH} -uid 503 ! -type l -exec chown 863242 {} \;
+RUN find /srv/app -uid 503 ! -type l -exec chown 863242 {} \;
 
 USER ckan
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,4 @@
 volumes:
-  ckan_storage:
-    driver_opts:
-      type: none
-      o: bind
-      device: /data/ckan
-  ckan_webassets:
   pg_data:
   solr_data:
   pip_cache_py310:
@@ -36,8 +30,8 @@ services:
       redis:
         condition: service_healthy
     volumes:
-      - /data/ckan:/var/lib/ckan
-      - ckan_webassets:/var/lib/ckan/webassets
+      - /data/ckan/resources:/var/lib/ckan/resources
+      - /data/ckan/storage:/var/lib/ckan/storage
       - pip_cache_py310:/root/.cache/pip
       - site_packages_py310:/usr/lib/python3.10/site-packages
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ volumes:
       type: none
       o: bind
       device: /data/ckan
+  ckan_webassets:
   pg_data:
   solr_data:
   pip_cache_py310:
@@ -36,6 +37,7 @@ services:
         condition: service_healthy
     volumes:
       - /data/ckan:/var/lib/ckan
+      - ckan_webassets:/var/lib/ckan/webassets
       - pip_cache_py310:/root/.cache/pip
       - site_packages_py310:/usr/lib/python3.10/site-packages
     restart: unless-stopped

--- a/docs/debug-corral-edquot.md
+++ b/docs/debug-corral-edquot.md
@@ -1,0 +1,162 @@
+# Debug: Corral EDQUOT on CKAN Resource Upload
+
+## Symptom
+
+Production CKAN raised `OSError: [Errno 122] Disk quota exceeded` when
+creating resources, blocking uploads.
+
+```
+File "/srv/app/src/ckan/ckan/lib/uploader.py", line 379, in upload
+    os.makedirs(directory)
+...
+mkdir(name, mode)
+[Errno 122] Disk quota exceeded: '/var/lib/ckan/resources/1d9'
+```
+
+The same error reappeared later under a different path:
+
+```
+PermissionError: [Errno 13] Permission denied: '/var/lib/ckan/webassets/.webassets-cache/14026a1632531c2b1445ac9963f41c0b'
+OSError: [Errno 122] Disk quota exceeded: '/var/lib/ckan/webassets/.webassets-cache'
+```
+
+`/var/lib/ckan` inside the CKAN container is bind-mounted from
+`/data/ckan` on the host, which is itself an NFSv3 mount of the TACC
+Corral allocation `BCS24011`:
+
+```
+129.114.52.151:/corral/main/utexas/BCS24011/ckan on /corral/utexas/BCS24011/ckan
+type nfs (rw,nosuid,rsize=1048576,wsize=1048576,intr,nfsvers=3,tcp)
+```
+
+## Investigation
+
+Phase 1 evidence (run on docker host):
+
+| Check | Result | Conclusion |
+|-------|--------|------------|
+| `df -h /corral/utexas/BCS24011/ckan` | 70% used (12P free) | Corral filesystem not full |
+| `df -i` | 81% inode used | Filesystem inode pool not exhausted |
+| `du -sh resources` | 29G | Tree itself tiny |
+| `stat resources` | owner `503:G-826671`, mode `0755` | Owned by container's default uid |
+| `docker compose exec ckan id` | `uid=503(ckan) gid=826671(ckan-sys)` | Container writes as uid 503 |
+| `sudo -u #863242 dd ... .qtest` at root | OK | uid 863242 has quota |
+| `sudo -u #863242 mkdir resources/qt_863242` | EACCES | Group r-x only on resources |
+| `docker compose exec ckan mkdir resources/qtestN` | EDQUOT | uid 503 has zero quota on Corral |
+| `sudo chown ...` from host | EACCES (root_squash) | NFS export squashes root |
+
+## Root Cause
+
+NFSv3 transmits the raw numeric uid from the client. The CKAN container
+shipped with default uid `503`, which is **not registered** in TACC's
+user database for project `BCS24011`. Corral therefore treats writes
+from uid 503 as quota-zero and returns `EDQUOT` for every write
+beneath the project tree.
+
+A secondary issue: directories newly created on the host inherited the
+shell user's primary group (`PT2050-DataX`) instead of the BCS24011
+group `826671`, because the parent directory had no setgid bit. Files
+written into those subdirs were billed against the wrong project's
+quota and again rejected with `EDQUOT`.
+
+## Fix
+
+### 1. Container uid mapped to a real TACC uid
+
+Patched `ckan/Dockerfile`:
+
+```dockerfile
+RUN groupmod -g 826671 ckan-sys && echo "Modified group ID for ckan-sys to 826671"
+RUN usermod  -u 863242 ckan    && echo "Modified user  ID for ckan to 863242"
+
+RUN find /var/lib/ckan        -uid 503 ! -type l -exec chown 863242 {} \;
+RUN find ${APP_DIR}           -uid 503 ! -type l -exec chown 863242 {} \;
+RUN find /docker-entrypoint.d -uid 503 ! -type l -exec chown 863242 {} \;
+RUN find /usr/local           -uid 503 ! -type l -exec chown 863242 {} \;
+RUN find ${CKAN_STORAGE_PATH} -uid 503 ! -type l -exec chown 863242 {} \;
+RUN find /srv/app             -uid 503 ! -type l -exec chown 863242 {} \;
+```
+
+Commit: `fe8db64 fix(docker): set ckan container uid to 863242 for Corral NFS writes`
+
+### 2. Existing data tree rechowned via copy+swap
+
+Root-squash on the NFS export prevents `chown` from the host even as
+root. Plain user `chown` from the container is also blocked by POSIX
+(non-root cannot transfer ownership). Workaround: copy the tree as
+mosorio (uid 863242), so the new copy is born with the correct owner,
+then atomically swap names.
+
+```bash
+docker compose stop ckan
+
+cd /corral/utexas/BCS24011/ckan
+cp -a resources resources.new        # owner 863242, gid 826671 (cp -a preserves gid for group members)
+mv resources resources.old
+mv resources.new resources
+
+setfacl -R    -m g:826671:rwx resources
+setfacl -R -d -m g:826671:rwx resources
+find resources -type d -exec chmod g+s {} \;
+
+docker compose up -d ckan
+```
+
+Keep `resources.old` until the next backup window confirms reads work.
+
+### 3. NFS bind narrowed to data subdirectories
+
+The original mount `/data/ckan:/var/lib/ckan` forced every subdirectory
+of `/var/lib/ckan` (webassets, runtime caches, etc.) through NFS. Only
+`resources/` and `storage/` actually need to persist on Corral; the
+rest can live in the container's image layer where uid 863242 already
+owns the paths.
+
+`docker-compose.yml`:
+
+```yaml
+services:
+  ckan:
+    volumes:
+      - /data/ckan/resources:/var/lib/ckan/resources
+      - /data/ckan/storage:/var/lib/ckan/storage
+      - pip_cache_py310:/root/.cache/pip
+      - site_packages_py310:/usr/lib/python3.10/site-packages
+```
+
+An earlier attempt to overlay a named volume at `/var/lib/ckan/webassets`
+on top of the wide bind mount was abandoned because runc could not
+traverse the NFS-bound parent during container init (root-squash denied
+the directory lookup).
+
+## Why The Bug Surfaced Now
+
+Earlier uwsgi/nginx fixes (`794f800`, `5f84c90`, `5e95674`) let large
+uploads complete the request body phase instead of being killed by
+harakiri. The uploader code path that calls `os.makedirs` is only
+reached after the body finishes streaming, so the underlying NFS uid
+mismatch had been masked by an earlier failure.
+
+## Verification
+
+```bash
+docker compose exec ckan id                                 # uid=863242(ckan)
+docker compose exec ckan touch /var/lib/ckan/resources/.qok && echo OK
+docker compose exec ckan touch /var/lib/ckan/webassets/.qok  && echo OK
+docker compose logs --tail=200 ckan | grep -iE 'quota|errno' || echo CLEAN
+```
+
+Then upload a real resource through the UI to confirm the end-to-end
+flow.
+
+## Follow-Up / Tech Debt
+
+- Hardcoding mosorio's personal TACC uid into the production image
+  ties CKAN's ability to write to one human's account. Open a TACC
+  ticket to provision a dedicated service account in BCS24011 and
+  switch the Dockerfile to that uid.
+- Add a default ACL `g:826671:rwx` and the setgid bit on
+  `/corral/utexas/BCS24011/ckan` so future top-level directories
+  inherit the correct group automatically.
+- Audit any remaining 503-owned directories under the Corral tree:
+  `find /corral/utexas/BCS24011/ckan -maxdepth 2 -uid 503`.

--- a/docs/debug-corral-edquot.md
+++ b/docs/debug-corral-edquot.md
@@ -124,10 +124,42 @@ services:
       - site_packages_py310:/usr/lib/python3.10/site-packages
 ```
 
+Commit: `433a5a7 fix(docker): narrow NFS bind to resources and storage subdirs`
+
 An earlier attempt to overlay a named volume at `/var/lib/ckan/webassets`
 on top of the wide bind mount was abandoned because runc could not
 traverse the NFS-bound parent during container init (root-squash denied
 the directory lookup).
+
+### 4. Squashed-root traversal bits on NFS parents
+
+After narrowing the bind, container init failed with:
+
+```
+mkdir /data/ckan/resources: permission denied
+```
+
+The Docker daemon stats the bind source as root. NFS root-squash maps
+that to anonymous, which had no `o+x` on the project tree (mode
+`drwxrwx---`). Fix as the directory owner (mosorio) — grant traversal
+only, no read/write to others:
+
+```bash
+chmod o+x /corral/utexas/BCS24011/ckan
+chmod o+x /corral/utexas/BCS24011/ckan/resources
+chmod o+x /corral/utexas/BCS24011/ckan/storage
+```
+
+### 5. procps installed for runtime debugging
+
+Default `ckan/ckan-base:2.11` lacks `ps`. Added `procps` to the
+Dockerfile apt step so worker uid/gid can be inspected at runtime:
+
+```bash
+docker compose exec ckan ps -eo pid,user,uid,gid,cmd | grep -i uwsgi
+```
+
+Commit: `6bb66af chore(docker): install procps for ps/top in ckan image`
 
 ## Why The Bug Surfaced Now
 
@@ -141,13 +173,47 @@ mismatch had been masked by an earlier failure.
 
 ```bash
 docker compose exec ckan id                                 # uid=863242(ckan)
-docker compose exec ckan touch /var/lib/ckan/resources/.qok && echo OK
-docker compose exec ckan touch /var/lib/ckan/webassets/.qok  && echo OK
+docker compose exec ckan ps -eo pid,user,uid,gid,cmd | grep uwsgi
+docker compose exec ckan touch /var/lib/ckan/resources/.qok && echo RES_OK
+docker compose exec ckan touch /var/lib/ckan/storage/.qok  && echo STO_OK
+docker compose exec ckan touch /var/lib/ckan/webassets/.qok && echo WEB_OK
+ls -la /corral/utexas/BCS24011/ckan/resources/.qok          # verify uid:gid on disk
 docker compose logs --tail=200 ckan | grep -iE 'quota|errno' || echo CLEAN
 ```
 
 Then upload a real resource through the UI to confirm the end-to-end
 flow.
+
+## Open Issues
+
+A regression resurfaced after applying steps 1-5: `os.makedirs` still
+returns `EDQUOT` on a deeper path:
+
+```
+OSError: [Errno 122] Disk quota exceeded: '/var/lib/ckan/resources/ced/37a'
+```
+
+Container `id` confirms `uid=863242(ckan) gid=826671(ckan-sys)`, so
+the failing process is running as the right uid. Working hypotheses:
+
+- A pre-existing intermediate directory (e.g. `resources/ced`) was
+  created before the rechown and still carries the wrong gid (likely
+  mosorio's primary group `PT2050-DataX` rather than `826671`). New
+  files inside inherit that gid because no setgid bit was set during
+  cp+swap, so Corral bills against an unallocated project.
+- A worker process (uwsgi forked, supervisor-managed, datapusher
+  callback) runs with a different uid/gid than the main container
+  process.
+
+Diagnostic commands queued:
+
+```bash
+docker compose exec ckan ps -efH
+docker compose exec ckan touch /var/lib/ckan/resources/.utest && \
+  ls -la /corral/utexas/BCS24011/ckan/resources/.utest
+ls -ld /corral/utexas/BCS24011/ckan/resources/ced
+find /corral/utexas/BCS24011/ckan/resources -maxdepth 3 ! -group G-826671 2>/dev/null | head
+```
 
 ## Follow-Up / Tech Debt
 
@@ -160,3 +226,5 @@ flow.
   inherit the correct group automatically.
 - Audit any remaining 503-owned directories under the Corral tree:
   `find /corral/utexas/BCS24011/ckan -maxdepth 2 -uid 503`.
+- Confirm uwsgi config drops privileges to `uid = ckan` rather than
+  running workers as root.


### PR DESCRIPTION
## Summary

Resource uploads in production failed with `OSError: [Errno 122] Disk quota exceeded` whenever CKAN tried to create a new directory under `/var/lib/ckan/resources` on the Corral-backed NFS mount.

Root cause: the project this CKAN deployment was attached to (`BCS24011`, gid `826671`) has **no Corral storage allocation**. NFS billed every new inode against gid 826671 and rejected it with `EDQUOT`. The `ckan` container also ran as the upstream image's default uid `503`, an identity unknown to TACC's user database, which further blocked writes.

This branch migrates the container's identity to `mosorio:PT2050-DataX` (uid `863242`, gid `820466`) — the project that actually carries the Corral storage allocation — and tightens the NFS bind mount to only the directories that need it.

## Changes

- `ckan/Dockerfile`
  - `usermod -u 863242 ckan`
  - `groupmod -g 820466 ckan-sys` (was 826671)
  - chown/chgrp sweeps for image paths owned by old uid 503 / gid 826671
  - Install `procps` so `ps` is available for runtime debugging
- `docker-compose.yml`
  - Replace `/data/ckan:/var/lib/ckan` with subdir binds for `resources/` and `storage/`. Webassets and other regenerable caches now live in the container's image layer.
- `docs/debug-corral-edquot.md`
  - Full runbook covering symptom, evidence, root cause, the cp+swap rechown procedure, the squashed-root traversal `o+x` requirement, and follow-up tech debt.

## Why PT2050-DataX

`BCS24011` exists as a directory under `/corral/utexas/`, but the project does not have its own storage allocation. Files persisted only because earlier writers happened to be billed against their own projects. Aligning everything to `PT2050-DataX (820466)` matches the allocation that backs this deployment today.

## Test Plan

- [ ] `docker compose build ckan && docker compose up -d ckan`
- [ ] `docker compose exec ckan id` -> `uid=863242(ckan) gid=820466(ckan-sys)`
- [ ] `docker compose exec ckan bash -c 'mkdir -p /var/lib/ckan/resources/zzz/test && echo OK'`
- [ ] New file on disk shows `mosorio:PT2050-DataX`
- [ ] Real resource upload via the UI completes without `EDQUOT`
- [ ] `docker compose logs --tail=200 ckan | grep -iE 'quota|errno'` returns no matches

## Follow-Up

- Open a TACC ticket to either (a) provision a Corral storage allocation for `BCS24011`, so the deployment can be retargeted to its logical owning project, or (b) provision a dedicated service account in `PT2050-DataX` instead of pinning the container to mosorio's personal uid.
- Add default ACL + setgid sweep to the deployment runbook so future top-level directories inherit the correct group automatically.