### PR TITLE
Keep CKAN webassets local; update NFS, nginx, docs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,8 @@ services:
       redis:
         condition: service_healthy
     volumes:
+      # Keep generated CKAN runtime paths (notably webassets) off Corral/NFS.
+      # Only uploaded/persistent data directories are bind-mounted.
       - /data/ckan/resources:/var/lib/ckan/resources
       - /data/ckan/storage:/var/lib/ckan/storage
       - pip_cache_py310:/root/.cache/pip
@@ -44,11 +46,12 @@ services:
           'wget',
           '-qO',
           '/dev/null',
-          'http://localhost:5000/api/action/status_show',
+          'http://localhost:5000/',
         ]
       interval: 60s
-      timeout: 10s
-      retries: 3
+      timeout: 30s
+      retries: 5
+      start_period: 90s
 
   datapusher:
     logging:

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -56,6 +56,12 @@ ssh root@129.114.97.55
 # Navigate to the deployment directory
 cd /srv/ckan-tacc-images
 
+# Use the webassets/nginx fix branch, not main
+BRANCH=117-ckan-html-pages-fail-when-webassets-cache-is-mounted-on-corralnfs-without-ckan-write-permissions
+git fetch origin
+git switch "$BRANCH" || git switch --track "origin/$BRANCH"
+git pull --ff-only
+
 # Rebuild and restart
 docker compose build
 docker compose up -d

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -3,34 +3,25 @@
 ## Architecture
 
 ```
-User -> ckan (129.114.97.106) -> ckan-tmp (129.114.97.55) -> Docker containers
-         nginx reverse proxy       nginx reverse proxy        CKAN on port 5000
+User -> ckan.tacc.utexas.edu -> host nginx -> CKAN container
+                                TLS/CORS      localhost:5000
 ```
 
-### ckan - 129.114.97.106 (old server)
+### CKAN host
 
-Reverse proxy that forwards all traffic to the new server. Handles SSL termination and the public-facing `ckan.tacc.utexas.edu` domain.
+Hosts the Docker Compose deployment. Nginx runs on the host, terminates TLS for `ckan.tacc.utexas.edu`, and proxies directly to the CKAN container on `127.0.0.1:5000`.
 
 - Nginx config: `/etc/nginx/conf.d/ckan-tacc-utexas.conf`
 - Reference copy: [docs/nginx/ckan-tacc-utexas.conf](nginx/ckan-tacc-utexas.conf)
 - SSL: Let's Encrypt (Certbot managed)
-- Proxies to: `https://129.114.97.55`
-- Upload limit: `client_max_body_size 10G`
-
-### ckan-tmp - 129.114.97.55 (new server)
-
-Hosts the Docker Compose deployment. Nginx runs on the host and proxies to the CKAN container on `localhost:5000`.
-
-- Nginx config: `/etc/nginx/conf.d/ckan-tacc-utexas.conf`
-- Reference copy: [docs/nginx/ckan-tmp-tacc-utexas.conf](nginx/ckan-tmp-tacc-utexas.conf)
-- SSL: Let's Encrypt (Certbot managed)
+- Proxies to: `http://127.0.0.1:5000`
 - Upload limit: `client_max_body_size 10G`
 - Serves LiDAR files directly from `/corral/utexas/BCS24011/ckan/lidar_files`
 - Handles CORS headers and media file range requests (video/audio seeking)
 
 ## Docker Compose
 
-Deployed at `/srv/ckan-tacc-images` on ckan-tmp (129.114.97.55).
+Deployed at `/srv/ckan-tacc-images` on the CKAN host (currently 129.114.97.55).
 
 ### Services
 
@@ -44,7 +35,9 @@ Deployed at `/srv/ckan-tacc-images` on ckan-tmp (129.114.97.55).
 
 ### Data Volumes
 
-- CKAN storage: `/data/ckan` (bind mount)
+- CKAN resources: `/data/ckan/resources` -> `/var/lib/ckan/resources`
+- CKAN storage: `/data/ckan/storage` -> `/var/lib/ckan/storage`
+- CKAN webassets: local container filesystem, intentionally not on Corral/NFS
 - PostgreSQL: `pg_data` (Docker volume)
 - Solr: `solr_data` (Docker volume)
 
@@ -57,7 +50,7 @@ Deployed at `/srv/ckan-tacc-images` on ckan-tmp (129.114.97.55).
 ### Common Commands
 
 ```bash
-# SSH into the new server
+# SSH into the CKAN host
 ssh root@129.114.97.55
 
 # Navigate to the deployment directory
@@ -79,3 +72,21 @@ docker compose exec ckan ckan sysadmin add <username>
 # Restart nginx (on host, not in Docker)
 systemctl reload nginx
 ```
+
+### Validation
+
+```bash
+# Local container/API paths
+curl -o /dev/null -s -w "local_api:%{time_total} code:%{http_code}\n" \
+  http://127.0.0.1:5000/api/3/action/status_show
+curl -o /dev/null -s -w "local_home:%{time_total} code:%{http_code}\n" \
+  http://127.0.0.1:5000/
+
+# Public paths through host nginx
+curl -k -o /dev/null -s -w "public_api:%{time_total} code:%{http_code}\n" \
+  https://ckan.tacc.utexas.edu/api/3/action/status_show
+curl -k -o /dev/null -s -w "public_home:%{time_total} code:%{http_code}\n" \
+  https://ckan.tacc.utexas.edu/
+```
+
+Both `local_home` and `public_home` must return `code:200`; those rendered-page checks catch webassets permission failures that API-only checks miss.

--- a/docs/nginx/ckan-tacc-utexas.conf
+++ b/docs/nginx/ckan-tacc-utexas.conf
@@ -2,48 +2,126 @@ map $http_origin $cors_origin {
     default "";
     "http://localhost:5500" $http_origin;
     ~^https?://localhost(:[0-9]+)?$ $http_origin;
-      ~^https?://mint\.local(:[0-9]+)?$ $http_origin;
+    ~^https?://mint\.local(:[0-9]+)?$ $http_origin;
     ~^https?://127\.0\.0\.1(:[0-9]+)?$ $http_origin;
     ~^https://.*\.github\.io$ $http_origin;
     ~^https://.*\.netlify\.app$ $http_origin;
     ~^https://.*\.tacc\.utexas\.edu$ $http_origin;
-    ~^https://([a-z0-9-]+\.)*pods\.portals\.tapis\.io$ $http_origin;   # ← ADD: SUBSIDE pods (subsideui…)
+    ~^https://([a-z0-9-]+\.)*pods\.portals\.tapis\.io$ $http_origin;
+}
 
+upstream ckan_app {
+    server 127.0.0.1:5000;
+    keepalive 32;
 }
 
 server {
-  server_name  ckan.tacc.utexas.edu;
-  access_log /var/log/nginx/ckan.access.log;
-  client_max_body_size 10G;
-  proxy_read_timeout 600s;
-  proxy_send_timeout 600s;
-  proxy_connect_timeout 60s;
-  client_body_timeout 600s;
-  listen [::]:443 ssl ipv6only=on; # managed by Certbot
-  listen 443 ssl; # managed by Certbot
-  ssl_certificate /etc/letsencrypt/live/ckan.tacc.utexas.edu/fullchain.pem; # managed by Certbot
-  ssl_certificate_key /etc/letsencrypt/live/ckan.tacc.utexas.edu/privkey.pem; # managed by Certbot
-  include /etc/letsencrypt/options-ssl-nginx.conf; # managed by Certbot
-  ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem; # managed by Certbot
+    server_name ckan.tacc.utexas.edu;
 
-  location / {
-      proxy_pass https://129.114.97.55;
-      proxy_set_header X-Forwarded-For $remote_addr;
-      proxy_set_header Host $host;
-      proxy_ssl_server_name on;
-      proxy_ssl_name ckan.tacc.utexas.edu;
-  }
+    listen [::]:443 ssl ipv6only=on; # managed by Certbot
+    listen 443 ssl; # managed by Certbot
+
+    access_log /var/log/nginx/ckan.access.log;
+    client_max_body_size 10G;
+    client_body_timeout 600s;
+    proxy_connect_timeout 60s;
+    proxy_read_timeout 600s;
+    proxy_send_timeout 600s;
+
+    ssl_certificate /etc/letsencrypt/live/ckan.tacc.utexas.edu/fullchain.pem; # managed by Certbot
+    ssl_certificate_key /etc/letsencrypt/live/ckan.tacc.utexas.edu/privkey.pem; # managed by Certbot
+    include /etc/letsencrypt/options-ssl-nginx.conf; # managed by Certbot
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem; # managed by Certbot
+
+    location ^~ /lidar_files {
+        root /corral/utexas/BCS24011/ckan/;
+        autoindex on;
+
+        if ($request_method = OPTIONS) {
+            add_header Access-Control-Allow-Origin "*" always;
+            add_header Access-Control-Allow-Methods "GET, POST, OPTIONS, PUT, DELETE" always;
+            add_header Access-Control-Allow-Headers "DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,Authorization" always;
+            add_header Access-Control-Max-Age 1728000 always;
+            add_header Content-Type "text/plain; charset=utf-8" always;
+            add_header Content-Length 0 always;
+            return 204;
+        }
+
+        add_header Access-Control-Allow-Origin "*" always;
+        add_header Access-Control-Allow-Methods "GET, POST, OPTIONS, PUT, DELETE" always;
+        add_header Access-Control-Allow-Headers "DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,Authorization" always;
+        add_header Access-Control-Expose-Headers "Content-Length,Content-Range,Accept-Ranges" always;
+    }
+
+    location / {
+        if ($request_method = OPTIONS) {
+            add_header Access-Control-Allow-Origin $cors_origin always;
+            add_header Access-Control-Allow-Methods "GET, POST, PUT, PATCH, DELETE, OPTIONS" always;
+            add_header Access-Control-Allow-Headers "DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,Authorization,X-CKAN-API-Key" always;
+            add_header Access-Control-Allow-Credentials "true" always;
+            add_header Access-Control-Max-Age 1728000 always;
+            add_header Content-Type "text/plain; charset=utf-8" always;
+            add_header Content-Length 0 always;
+            return 204;
+        }
+
+        add_header Access-Control-Allow-Origin $cors_origin always;
+        add_header Access-Control-Allow-Methods "GET, POST, PUT, PATCH, DELETE, OPTIONS" always;
+        add_header Access-Control-Allow-Headers "DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,Authorization,X-CKAN-API-Key" always;
+        add_header Access-Control-Expose-Headers "Content-Length,Content-Range,Accept-Ranges" always;
+        add_header Access-Control-Allow-Credentials "true" always;
+        add_header Vary "Origin" always;
+
+        proxy_pass http://ckan_app;
+        proxy_http_version 1.1;
+        proxy_set_header Connection "";
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-Port 443;
+        proxy_redirect off;
+    }
+
+    location ~* \.(mp4|webm|ogg|avi|mov|wmv|flv|m4v|mp3|wav|aac|flac|m4a|wma|opus|aiff|au|ra)$ {
+        if ($request_method = OPTIONS) {
+            add_header Access-Control-Allow-Origin "*" always;
+            add_header Access-Control-Allow-Methods "GET, HEAD, OPTIONS" always;
+            add_header Access-Control-Allow-Headers "Range,Content-Range,Authorization" always;
+            add_header Access-Control-Max-Age 86400 always;
+            add_header Content-Type "text/plain" always;
+            add_header Content-Length 0 always;
+            return 204;
+        }
+
+        add_header Accept-Ranges "bytes" always;
+        add_header Cache-Control "public, max-age=86400" always;
+        add_header Access-Control-Allow-Origin "*" always;
+        add_header Access-Control-Allow-Methods "GET, HEAD, OPTIONS" always;
+        add_header Access-Control-Allow-Headers "Range,Content-Range,Authorization" always;
+        add_header Access-Control-Expose-Headers "Accept-Ranges,Content-Range,Content-Length" always;
+
+        proxy_pass http://ckan_app;
+        proxy_http_version 1.1;
+        proxy_set_header Connection "";
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-Port 443;
+        proxy_set_header Range $http_range;
+        proxy_set_header If-Range $http_if_range;
+        proxy_cache_bypass $http_range;
+        proxy_no_cache $http_range;
+        proxy_redirect off;
+    }
 }
+
 server {
-    if ($host = ckan.tacc.utexas.edu) {
-        return 301 https://$host$request_uri;
-    } # managed by Certbot
-
-
-    listen       80;
-    listen  [::]:80;
-    server_name  ckan.tacc.utexas.edu;
-    return 404; # managed by Certbot
-
-
+    listen 80;
+    listen [::]:80;
+    server_name ckan.tacc.utexas.edu;
+    return 301 https://$host$request_uri;
 }

--- a/scripts/nfs-storage/README.md
+++ b/scripts/nfs-storage/README.md
@@ -1,12 +1,12 @@
 # NFS Corral Storage Setup for CKAN
 
-Mount TACC Corral NFS storage on a new server so the CKAN Docker container can read and write dataset files. The NFS export provides persistent storage at `/var/lib/ckan` inside the container, backed by TACC's Corral filesystem (allocation BCS24011).
+Mount TACC Corral NFS storage on a new server so the CKAN Docker container can read and write uploaded dataset files. The NFS export backs only the CKAN `resources/` and `storage/` directories; generated runtime paths such as `webassets/` stay local to the container.
 
 ## Prerequisites
 
 - Root access on the target server
 - Docker and docker compose installed
-- Production CKAN image built (uses `ckan/Dockerfile` which remaps GID to 826671)
+- Production CKAN image built (uses `ckan/Dockerfile` which remaps the CKAN user to uid `863242`, gid `820466`)
 
 ## Quick Start
 
@@ -54,19 +54,20 @@ Host: /corral/utexas/BCS24011/ckan
        v
 Host: /data/ckan
        |
-       | Docker bind mount (docker-compose.yml)
+       | Docker bind mounts (docker-compose.yml)
        v
-Container: /var/lib/ckan
-       accessed by ckan user (uid=503, gid=826671)
+Container: /var/lib/ckan/resources
+Container: /var/lib/ckan/storage
+       accessed by ckan user (uid=863242, gid=820466)
 ```
 
 - **NFS mount** brings Corral storage to the host at `/corral/utexas/BCS24011/ckan`
 - **Symlink** `/data/ckan` points to the mount (matches docker-compose.yml volume definition)
-- **Docker bind mount** maps `/data/ckan` on the host to `/var/lib/ckan` in the container
-- **Container user** `ckan` (uid=503, gid=826671) accesses files via group permissions
-- **GID remapping** is handled by the production Dockerfile: `groupmod -g 826671 ckan-sys` changes the base image's default GID (502) to match TACC's Corral group
+- **Docker bind mounts** map `/data/ckan/resources` and `/data/ckan/storage` to the matching container subdirectories
+- **Container user** `ckan` (uid=863242, gid=820466) accesses files via ownership/group permissions
+- **UID/GID remapping** is handled by the production Dockerfile: `usermod -u 863242 ckan` and `groupmod -g 820466 ckan-sys`
 
-Files on Corral are owned by various TACC user UIDs but share the `ckan-sys` group (826671). The container accesses everything through group permissions.
+Generated CKAN webassets are intentionally not stored on Corral/NFS. They are rebuilt by CKAN as needed and should remain writable inside the container filesystem.
 
 ## Troubleshooting
 
@@ -76,12 +77,12 @@ The server is not whitelisted for Corral NFS access. Contact TACC sysadmin to re
 
 ### Permission denied inside container
 
-The wrong Dockerfile was used. The dev Dockerfile (`ckan/Dockerfile.dev`) does NOT remap the GID. Use the production Dockerfile (`ckan/Dockerfile`) which includes `groupmod -g 826671 ckan-sys`.
+The wrong Dockerfile was used. The dev Dockerfile (`ckan/Dockerfile.dev`) does NOT remap the production UID/GID. Use the production Dockerfile (`ckan/Dockerfile`) which includes `usermod -u 863242 ckan` and `groupmod -g 820466 ckan-sys`.
 
 Verify with:
 ```bash
 docker compose exec ckan id
-# Expected: uid=503(ckan) gid=826671(ckan-sys)
+# Expected: uid=863242(ckan) gid=820466(ckan-sys)
 # Wrong:    uid=503(ckan) gid=502(ckan-sys)
 ```
 
@@ -131,7 +132,7 @@ docker compose restart
 |------|-------------|
 | `/corral/utexas/BCS24011/ckan` | NFS mount point on host |
 | `/data/ckan` | Symlink to mount point (used by docker-compose.yml) |
-| `/var/lib/ckan` | Storage path inside CKAN container |
+| `/var/lib/ckan` | CKAN runtime path inside the container |
 | `/var/lib/ckan/resources` | CKAN resource files |
 | `/var/lib/ckan/storage` | CKAN file storage |
-| `/var/lib/ckan/webassets` | CKAN compiled web assets |
+| `/var/lib/ckan/webassets` | CKAN compiled web assets, local to the container |

--- a/scripts/nfs-storage/verify-nfs-storage.sh
+++ b/scripts/nfs-storage/verify-nfs-storage.sh
@@ -8,7 +8,8 @@ set -euo pipefail
 
 MOUNT_POINT="/corral/utexas/BCS24011/ckan"
 DATA_SYMLINK="/data/ckan"
-EXPECTED_GID=826671
+EXPECTED_UID=863242
+EXPECTED_GID=820466
 FAILURES=0
 
 echo "=== NFS Mount Verification ==="
@@ -56,26 +57,33 @@ echo ""
 
 # 3. Host write check
 echo "--- Host Write Access ---"
-if touch "${DATA_SYMLINK}/.nfs-write-test" 2>/dev/null; then
-    rm -f "${DATA_SYMLINK}/.nfs-write-test"
-    echo "[OK] Host can write to ${DATA_SYMLINK}"
-else
-    echo "[FAIL] Host cannot write to ${DATA_SYMLINK}"
-    echo "       Fix: Check group permissions on the NFS mount"
-    FAILURES=$((FAILURES + 1))
-fi
+for dir in resources storage; do
+    if [[ -d "${DATA_SYMLINK}/${dir}" ]] && touch "${DATA_SYMLINK}/${dir}/.nfs-write-test" 2>/dev/null; then
+        rm -f "${DATA_SYMLINK}/${dir}/.nfs-write-test"
+        echo "[OK] Host can write to ${DATA_SYMLINK}/${dir}"
+    else
+        echo "[WARN] Host user cannot write to ${DATA_SYMLINK}/${dir}"
+        echo "       Container write checks below are authoritative for CKAN."
+    fi
+done
 
 echo ""
 
 # 4. Directory check
 echo "--- Expected Directories ---"
-for dir in resources storage webassets; do
+for dir in resources storage; do
     if [[ -d "${DATA_SYMLINK}/${dir}" ]]; then
         echo "[OK] ${DATA_SYMLINK}/${dir}/ exists"
     else
-        echo "[WARN] ${DATA_SYMLINK}/${dir}/ missing (CKAN creates it on first run)"
+        echo "[FAIL] ${DATA_SYMLINK}/${dir}/ missing; docker-compose bind mounts require this host path"
+        FAILURES=$((FAILURES + 1))
     fi
 done
+if [[ -d "${DATA_SYMLINK}/webassets" ]]; then
+    echo "[WARN] ${DATA_SYMLINK}/webassets/ exists on NFS but should not be mounted into the CKAN container"
+else
+    echo "[OK] webassets is not expected on NFS; CKAN keeps it local to the container"
+fi
 
 echo ""
 
@@ -88,11 +96,11 @@ if docker compose ps --status running 2>/dev/null | grep -q "ckan"; then
     CONTAINER_ID_OUTPUT=$(docker compose exec -T ckan id 2>/dev/null || true)
     if [[ -n "${CONTAINER_ID_OUTPUT}" ]]; then
         echo "[INFO] Container user: ${CONTAINER_ID_OUTPUT}"
-        if echo "${CONTAINER_ID_OUTPUT}" | grep -q "gid=${EXPECTED_GID}"; then
-            echo "[OK] Container GID matches expected (${EXPECTED_GID})"
+        if echo "${CONTAINER_ID_OUTPUT}" | grep -q "uid=${EXPECTED_UID}" && echo "${CONTAINER_ID_OUTPUT}" | grep -q "gid=${EXPECTED_GID}"; then
+            echo "[OK] Container UID/GID match expected (${EXPECTED_UID}:${EXPECTED_GID})"
         else
-            echo "[FAIL] Container GID does not match expected (${EXPECTED_GID})"
-            echo "       Fix: Use production Dockerfile (not dev) which runs groupmod -g ${EXPECTED_GID} ckan-sys"
+            echo "[FAIL] Container UID/GID do not match expected (${EXPECTED_UID}:${EXPECTED_GID})"
+            echo "       Fix: Use production Dockerfile (not dev) which remaps ckan to ${EXPECTED_UID}:${EXPECTED_GID}"
             FAILURES=$((FAILURES + 1))
         fi
     else
@@ -102,12 +110,28 @@ if docker compose ps --status running 2>/dev/null | grep -q "ckan"; then
     echo ""
 
     # 5b. Container write access
-    if docker compose exec -T ckan touch /var/lib/ckan/.container-write-test 2>/dev/null; then
-        docker compose exec -T ckan rm -f /var/lib/ckan/.container-write-test 2>/dev/null
-        echo "[OK] Container can write to /var/lib/ckan"
+    if docker compose exec -T ckan touch /var/lib/ckan/resources/.container-write-test 2>/dev/null; then
+        docker compose exec -T ckan rm -f /var/lib/ckan/resources/.container-write-test 2>/dev/null
+        echo "[OK] Container can write to /var/lib/ckan/resources"
     else
-        echo "[FAIL] Container cannot write to /var/lib/ckan"
-        echo "       Fix: Check that container GID (${EXPECTED_GID}) has write access to NFS mount"
+        echo "[FAIL] Container cannot write to /var/lib/ckan/resources"
+        echo "       Fix: Check Corral ownership/permissions for ${DATA_SYMLINK}/resources"
+        FAILURES=$((FAILURES + 1))
+    fi
+    if docker compose exec -T ckan touch /var/lib/ckan/storage/.container-write-test 2>/dev/null; then
+        docker compose exec -T ckan rm -f /var/lib/ckan/storage/.container-write-test 2>/dev/null
+        echo "[OK] Container can write to /var/lib/ckan/storage"
+    else
+        echo "[FAIL] Container cannot write to /var/lib/ckan/storage"
+        echo "       Fix: Check Corral ownership/permissions for ${DATA_SYMLINK}/storage"
+        FAILURES=$((FAILURES + 1))
+    fi
+    if docker compose exec -T ckan touch /var/lib/ckan/webassets/.container-write-test 2>/dev/null; then
+        docker compose exec -T ckan rm -f /var/lib/ckan/webassets/.container-write-test 2>/dev/null
+        echo "[OK] Container can write to local /var/lib/ckan/webassets"
+    else
+        echo "[FAIL] Container cannot write to local /var/lib/ckan/webassets"
+        echo "       Fix: Rebuild production image and confirm webassets is not mounted from NFS"
         FAILURES=$((FAILURES + 1))
     fi
 

--- a/src/ckanext-tacc_theme/ckanext/tacc_theme/public/api-specs/ckan-openapi.json
+++ b/src/ckanext-tacc_theme/ckanext/tacc_theme/public/api-specs/ckan-openapi.json
@@ -1,0 +1,1126 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "TACC CKAN Action API",
+    "description": "OpenAPI description for common CKAN action API endpoints exposed by the TACC CKAN portal.",
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "/api/3/action",
+      "description": "CKAN action API"
+    }
+  ],
+  "tags": [
+    {
+      "name": "System"
+    },
+    {
+      "name": "Packages"
+    },
+    {
+      "name": "Resources"
+    },
+    {
+      "name": "Organizations"
+    },
+    {
+      "name": "Groups"
+    }
+  ],
+  "paths": {
+    "/status_show": {
+      "get": {
+        "tags": [
+          "System"
+        ],
+        "summary": "Show CKAN status",
+        "description": "Returns basic status and version information for the CKAN instance.",
+        "responses": {
+          "200": {
+            "description": "CKAN status",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActionResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/package_search": {
+      "get": {
+        "tags": [
+          "Packages"
+        ],
+        "summary": "Search datasets",
+        "parameters": [
+          {
+            "name": "q",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Full-text search query"
+          },
+          {
+            "name": "fq",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Solr filter query"
+          },
+          {
+            "name": "rows",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "default": 10,
+              "minimum": 0
+            }
+          },
+          {
+            "name": "start",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "default": 0,
+              "minimum": 0
+            }
+          },
+          {
+            "name": "sort",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Sort expression, for example metadata_modified desc"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Dataset search results",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PackageSearchResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/package_show": {
+      "get": {
+        "tags": [
+          "Packages"
+        ],
+        "summary": "Show dataset",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Dataset id or name"
+          },
+          {
+            "name": "include_tracking",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Dataset details",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PackageShowResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/package_create": {
+      "post": {
+        "tags": [
+          "Packages"
+        ],
+        "summary": "Create dataset",
+        "security": [
+          {
+            "ckanApiKey": []
+          },
+          {
+            "ckanApiKeyLegacy": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PackageCreateRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Created dataset",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PackageShowResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/package_update": {
+      "post": {
+        "tags": [
+          "Packages"
+        ],
+        "summary": "Replace dataset",
+        "description": "Updates a dataset. CKAN expects the full dataset object for package_update.",
+        "security": [
+          {
+            "ckanApiKey": []
+          },
+          {
+            "ckanApiKeyLegacy": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PackageUpdateRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated dataset",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PackageShowResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/package_patch": {
+      "post": {
+        "tags": [
+          "Packages"
+        ],
+        "summary": "Patch dataset",
+        "description": "Updates selected dataset fields.",
+        "security": [
+          {
+            "ckanApiKey": []
+          },
+          {
+            "ckanApiKeyLegacy": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PackagePatchRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Patched dataset",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PackageShowResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/resource_show": {
+      "get": {
+        "tags": [
+          "Resources"
+        ],
+        "summary": "Show resource",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Resource id"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource details",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ResourceShowResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/resource_create": {
+      "post": {
+        "tags": [
+          "Resources"
+        ],
+        "summary": "Create resource",
+        "security": [
+          {
+            "ckanApiKey": []
+          },
+          {
+            "ckanApiKeyLegacy": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ResourceCreateRequest"
+              }
+            },
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/ResourceCreateMultipartRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Created resource",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ResourceShowResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/resource_update": {
+      "post": {
+        "tags": [
+          "Resources"
+        ],
+        "summary": "Replace resource",
+        "security": [
+          {
+            "ckanApiKey": []
+          },
+          {
+            "ckanApiKeyLegacy": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ResourceUpdateRequest"
+              }
+            },
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/ResourceUpdateMultipartRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated resource",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ResourceShowResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/resource_patch": {
+      "post": {
+        "tags": [
+          "Resources"
+        ],
+        "summary": "Patch resource",
+        "security": [
+          {
+            "ckanApiKey": []
+          },
+          {
+            "ckanApiKeyLegacy": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ResourcePatchRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Patched resource",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ResourceShowResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/organization_list": {
+      "get": {
+        "tags": [
+          "Organizations"
+        ],
+        "summary": "List organizations",
+        "parameters": [
+          {
+            "name": "all_fields",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "include_dataset_count",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Organizations",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActionResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/organization_show": {
+      "get": {
+        "tags": [
+          "Organizations"
+        ],
+        "summary": "Show organization",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Organization id or name"
+          },
+          {
+            "name": "include_datasets",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Organization details",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OrganizationShowResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/group_list": {
+      "get": {
+        "tags": [
+          "Groups"
+        ],
+        "summary": "List groups",
+        "parameters": [
+          {
+            "name": "all_fields",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "include_dataset_count",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Groups",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActionResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/group_show": {
+      "get": {
+        "tags": [
+          "Groups"
+        ],
+        "summary": "Show group",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Group id or name"
+          },
+          {
+            "name": "include_datasets",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Group details",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GroupShowResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "ckanApiKey": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "Authorization",
+        "description": "CKAN API token"
+      },
+      "ckanApiKeyLegacy": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "X-CKAN-API-Key",
+        "description": "Legacy CKAN API key header"
+      }
+    },
+    "schemas": {
+      "ActionResponse": {
+        "type": "object",
+        "required": [
+          "help",
+          "success"
+        ],
+        "properties": {
+          "help": {
+            "type": "string"
+          },
+          "success": {
+            "type": "boolean"
+          },
+          "result": {
+            "nullable": true
+          },
+          "error": {
+            "type": "object",
+            "additionalProperties": true
+          }
+        },
+        "additionalProperties": true
+      },
+      "PackageSearchResponse": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ActionResponse"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "result": {
+                "type": "object",
+                "properties": {
+                  "count": {
+                    "type": "integer"
+                  },
+                  "sort": {
+                    "type": "string"
+                  },
+                  "results": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/Package"
+                    }
+                  },
+                  "search_facets": {
+                    "type": "object",
+                    "additionalProperties": true
+                  }
+                },
+                "additionalProperties": true
+              }
+            }
+          }
+        ]
+      },
+      "PackageShowResponse": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ActionResponse"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "result": {
+                "$ref": "#/components/schemas/Package"
+              }
+            }
+          }
+        ]
+      },
+      "ResourceShowResponse": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ActionResponse"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "result": {
+                "$ref": "#/components/schemas/Resource"
+              }
+            }
+          }
+        ]
+      },
+      "OrganizationShowResponse": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ActionResponse"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "result": {
+                "$ref": "#/components/schemas/Organization"
+              }
+            }
+          }
+        ]
+      },
+      "GroupShowResponse": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ActionResponse"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "result": {
+                "$ref": "#/components/schemas/Group"
+              }
+            }
+          }
+        ]
+      },
+      "PackageCreateRequest": {
+        "type": "object",
+        "required": [
+          "name",
+          "title",
+          "owner_org"
+        ],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "notes": {
+            "type": "string"
+          },
+          "owner_org": {
+            "type": "string",
+            "description": "Organization id or name"
+          },
+          "private": {
+            "type": "boolean"
+          },
+          "resources": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ResourceInput"
+            }
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Tag"
+            }
+          },
+          "extras": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extra"
+            }
+          }
+        },
+        "additionalProperties": true
+      },
+      "PackageUpdateRequest": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/PackageCreateRequest"
+          },
+          {
+            "type": "object",
+            "required": [
+              "id"
+            ],
+            "properties": {
+              "id": {
+                "type": "string",
+                "description": "Dataset id or name"
+              }
+            }
+          }
+        ]
+      },
+      "PackagePatchRequest": {
+        "type": "object",
+        "required": [
+          "id"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Dataset id or name"
+          },
+          "name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "notes": {
+            "type": "string"
+          },
+          "owner_org": {
+            "type": "string"
+          },
+          "private": {
+            "type": "boolean"
+          },
+          "resources": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ResourceInput"
+            }
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Tag"
+            }
+          },
+          "extras": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extra"
+            }
+          }
+        },
+        "additionalProperties": true
+      },
+      "ResourceCreateRequest": {
+        "type": "object",
+        "required": [
+          "package_id"
+        ],
+        "properties": {
+          "package_id": {
+            "type": "string",
+            "description": "Parent dataset id or name"
+          },
+          "url": {
+            "type": "string",
+            "format": "uri"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "format": {
+            "type": "string"
+          },
+          "mimetype": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": true
+      },
+      "ResourceCreateMultipartRequest": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ResourceCreateRequest"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "upload": {
+                "type": "string",
+                "format": "binary",
+                "description": "Uploaded resource file"
+              }
+            }
+          }
+        ]
+      },
+      "ResourceUpdateRequest": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ResourceCreateRequest"
+          },
+          {
+            "type": "object",
+            "required": [
+              "id"
+            ],
+            "properties": {
+              "id": {
+                "type": "string",
+                "description": "Resource id"
+              }
+            }
+          }
+        ]
+      },
+      "ResourceUpdateMultipartRequest": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ResourceUpdateRequest"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "upload": {
+                "type": "string",
+                "format": "binary",
+                "description": "Replacement uploaded resource file"
+              }
+            }
+          }
+        ]
+      },
+      "ResourcePatchRequest": {
+        "type": "object",
+        "required": [
+          "id"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Resource id"
+          },
+          "package_id": {
+            "type": "string",
+            "description": "Parent dataset id or name"
+          },
+          "url": {
+            "type": "string",
+            "format": "uri"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "format": {
+            "type": "string"
+          },
+          "mimetype": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": true
+      },
+      "Package": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "notes": {
+            "type": "string"
+          },
+          "owner_org": {
+            "type": "string"
+          },
+          "organization": {
+            "$ref": "#/components/schemas/Organization"
+          },
+          "resources": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Resource"
+            }
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Tag"
+            }
+          },
+          "extras": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Extra"
+            }
+          },
+          "metadata_created": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "metadata_modified": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "additionalProperties": true
+      },
+      "Resource": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "package_id": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "format": {
+            "type": "string"
+          },
+          "mimetype": {
+            "type": "string"
+          },
+          "created": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "last_modified": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          }
+        },
+        "additionalProperties": true
+      },
+      "ResourceInput": {
+        "type": "object",
+        "properties": {
+          "url": {
+            "type": "string",
+            "format": "uri"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "format": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": true
+      },
+      "Organization": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "image_url": {
+            "type": "string"
+          },
+          "package_count": {
+            "type": "integer"
+          }
+        },
+        "additionalProperties": true
+      },
+      "Group": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "image_url": {
+            "type": "string"
+          },
+          "package_count": {
+            "type": "integer"
+          }
+        },
+        "additionalProperties": true
+      },
+      "Tag": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "display_name": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": true
+      },
+      "Extra": {
+        "type": "object",
+        "required": [
+          "key",
+          "value"
+        ],
+        "properties": {
+          "key": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": true
+      }
+    }
+  }
+}


### PR DESCRIPTION
Avoid mounting CKAN-generated runtime paths (webassets) on Corral/NFS and document the change across compose, nginx, and NFS tooling.

- docker-compose.yml: added comment clarifying only resources/storage are bind-mounted; tightened CKAN healthcheck (timeout/retries/start_period).
- docs/deployment.md: updated architecture and deployment notes to reflect host nginx proxying to 127.0.0.1:5000, explicit mount mappings, and added local/public validation curl checks.
- docs/nginx/ckan-tacc-utexas.conf: replaced old proxy config with an upstream to 127.0.0.1:5000, added CORS handling, lidar_files static listing, media range handling, and HTTP->HTTPS redirect.
- scripts/nfs-storage/README.md: clarified which directories are backed by Corral, updated production UID/GID remapping details, and emphasized webassets remain local to the container.
- scripts/nfs-storage/verify-nfs-storage.sh: adjusted EXPECTED UID/GID, per-directory host-write checks, stricter existence checks for bind-mounted host paths, container write tests for resources/storage/webassets, and improved failure/warning messages.

These changes ensure webassets are writable in-container, reduce NFS permission problems, and improve operational validation and documentation.